### PR TITLE
chore: branch-protection config + lefthook PATH fix

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Source of truth for main's branch protection. To re-apply: gh api -X PUT /repos/LPettay/dwell/branches/main/protection --input <(jq 'del(._comment)' .github/branch-protection.json)",
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["hygiene"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false,
+  "required_linear_history": false
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,12 +4,16 @@
 # Bypass with --no-verify only in emergencies. Document why in your commit
 # message if you do.
 
+# Lefthook spawns subprocesses that don't inherit the user's interactive shell
+# rc files, so PATH may not include ~/.bun/bin (bun's default install location
+# on Linux + macOS). Prepend it explicitly so `bun` resolves regardless of how
+# the parent process was launched.
 pre-commit:
   parallel: true
   commands:
     repo-checks:
-      run: bun run check
+      run: PATH="$HOME/.bun/bin:$PATH" bun run check
       stage_fixed: false
     typecheck:
       glob: "**/*.ts"
-      run: bun run typecheck
+      run: PATH="$HOME/.bun/bin:$PATH" bun run typecheck


### PR DESCRIPTION
## Summary

- Adds `.github/branch-protection.json` as the source of truth for `main`'s protection rules (which are already live on GitHub — this commits the canonical config so future re-applications are reproducible).
- Fixes `lefthook.yml` to prepend `~/.bun/bin` to PATH inside hook commands so `bun` resolves on dev boxes where the user's interactive shell rc isn't sourced by non-interactive git hooks.

## Test plan

- [x] \`bun run check\` passes locally
- [x] Pre-commit hook resolved \`bun\` correctly on this commit (was failing before the fix)
- [ ] CI \`hygiene\` job passes on this PR