### PR TITLE
fix(cli): tolerate bare hostnames; useful error on malformed URLs

### DIFF
--- a/src/cli/dwell.ts
+++ b/src/cli/dwell.ts
@@ -19,7 +19,25 @@ function parseArgs(argv: string[]): { url: string; durationMs?: number; headed: 
     console.error("usage: dwell <url> [--duration <seconds>] [--headless]");
     process.exit(2);
   }
+  url = normalizeUrl(url);
   return { url, ...(durationMs !== undefined ? { durationMs } : {}), headed };
+}
+
+/**
+ * Accept bare hostnames (`example.com`) and add `https://` when no scheme is
+ * present. Anything with an existing scheme passes through. Genuinely
+ * malformed input exits with a useful argparse-style error rather than a
+ * downstream stack trace.
+ */
+export function normalizeUrl(input: string): string {
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(input) ? input : `https://${input}`;
+  try {
+    new URL(candidate);
+    return candidate;
+  } catch {
+    console.error(`error: '${input}' is not a valid URL`);
+    process.exit(2);
+  }
 }
 
 function slugHost(url: string): string {
@@ -61,7 +79,10 @@ async function main() {
   console.log(`\n  ${impression.oneSentenceVerdict}\n`);
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.stack ?? err.message : err);
-  process.exit(1);
-});
+// Only run when invoked as the entry point (not when imported, e.g. by tests).
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.stack ?? err.message : err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

\`dwell example.com\` previously crashed with a TypeError stack trace because \`new URL(\"example.com\")\` throws when no scheme is present.

This PR adds \`normalizeUrl()\` in \`src/cli/dwell.ts\` that:

- Prepends \`https://\` when no scheme is detected.
- Passes through \`http://\` and \`https://\` unchanged.
- Validates the result with \`new URL()\` and exits 2 with a one-line argparse-style error if the input is genuinely malformed (e.g. \`://malformed\`).

Also gates the top-level \`main()\` invocation behind \`import.meta.main\` so the module can be imported for tests / smoke checks without auto-executing.

## Smoke test (local)

\`\`\`
example.com              -> https://example.com
https://example.com      -> https://example.com
http://example.com       -> http://example.com
localhost:3000           -> https://localhost:3000
sub.example.com/path?q=1 -> https://sub.example.com/path?q=1
://malformed             -> error: '://malformed' is not a valid URL  (exit 2)
\`\`\`

## Test plan

- [x] \`bun run check\` passes locally
- [x] \`bun run typecheck\` passes locally
- [x] Pre-commit hook ran cleanly (no \`--no-verify\`)
- [x] Smoke-tested \`normalizeUrl\` on the cases above
- [ ] CI \`hygiene\` job passes

Closes #7.