### PR TITLE
feat(reason): dense frame extraction + validation pass on stop-words

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Details a single-screenshot pipeline cannot see.
 
 ## Quick start
 
-> Requires [Bun](https://bun.sh) ≥ 1.1, a Google AI Studio key, and a display server (WSLg works on WSL2; native X/Wayland everywhere else).
+> Requires [Bun](https://bun.sh) ≥ 1.1, a Google AI Studio key, `ffmpeg` on PATH (for dense-frame extraction), and a display server (WSLg works on WSL2; native X/Wayland everywhere else).
 
 ```bash
 bun install
 bun playwright install chromium    # if not already cached
+ffmpeg -version                     # must be on PATH; install via your package manager if missing
 echo "GEMINI_API_KEY=..." > .env
 
 bun run dwell https://fireside.technology/

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,29 +8,25 @@ The dwell library + CLI. Three stages, in this order: drive → capture → reas
 
 | Path | Purpose |
 |---|---|
+| [`capture/`](./capture/AGENTS.md) | Post-recording helpers (frame extraction, log compaction). ffmpeg / ffprobe wrappers live here. |
 | [`cli/`](./cli/AGENTS.md) | The `dwell` CLI entry point. Argv parsing, orchestration, file output. |
 | [`drive/`](./drive/AGENTS.md) | Playwright session driver — the dwelling choreography. |
 | [`reason/`](./reason/AGENTS.md) | Vision-model boundary — recording artifact → impression. |
 | [`types/`](./types/AGENTS.md) | Zod schemas: `InteractionEvent`, `SessionManifest`, `Impression`. |
-
-### Planned (not yet created)
-
-| Path | Purpose | Pointer |
-|---|---|---|
-| `capture/` | Reserved for video/log post-processing helpers (frame extraction, log compaction) if they ever grow beyond what `drive/` handles inline. | None — landed when needed. |
 
 ---
 
 ## Dependency direction
 
 ```
-cli/  →  drive/, reason/, types/
-drive/ →  types/
-reason/ →  types/
-types/  → (leaf, depends on nothing internal)
+cli/      →  drive/, reason/, types/
+drive/    →  types/
+reason/   →  capture/, types/
+capture/  →  (leaf — node stdlib + ffmpeg subprocess only)
+types/    →  (leaf, depends on nothing internal)
 ```
 
-`cli/` depends on everything below; `types/` depends on nothing. Never invert this. If `drive/` needs something from `reason/`, it's a smell — push the shared piece down into `types/` or extract a new lib.
+`cli/` depends on everything below; `types/` and `capture/` are leaves. Never invert this. If `drive/` needs something from `reason/`, it's a smell — push the shared piece down into `types/` or extract a new lib.
 
 ## What belongs in src/
 

--- a/src/capture/AGENTS.md
+++ b/src/capture/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — src/capture/
+
+Post-recording helpers that extract structured artifacts from what the driver produced. The driver writes raw webm + per-phase screenshots; capture turns those into things the reasoning step can consume.
+
+## Index
+
+### Files here
+
+| File | Purpose |
+|---|---|
+| `extract-frames.ts` | `extractFrames(webm, outDir, { intervalSeconds, maxFrames })` — pulls evenly-spaced PNG frames from a webm via ffmpeg's `fps=1/N` filter. Used by `reason/` to mitigate sparse-event aliasing (ADR 0005). |
+
+---
+
+## What belongs here
+
+- Pure, side-effecting helpers that operate on the recording artifact.
+- ffmpeg / ffprobe wrappers.
+- Future: log compaction, network-trace summarization, audio extraction.
+
+## What does not belong here
+
+- Anything that talks to a model — that's `../reason/`.
+- Anything that drives the browser — that's `../drive/`.
+- Filesystem layout decisions — those are made by the CLI / drive layer; capture consumes paths it's given.
+
+## Conventions
+
+- Helpers throw on hard failure (ffmpeg missing, unreadable webm). Callers in `reason/` decide whether to fall back gracefully.
+- Output directories are passed in by the caller — capture never invents paths.
+- Spawn external processes with explicit args, no shell expansion.
+- ffmpeg is required to be on `PATH`; document this in the README quick-start. Playwright also bundles ffmpeg under `~/.cache/ms-playwright/ffmpeg-*`, but we don't reach for it — keeping the dependency explicit is more honest than auto-discovering Playwright's internals.
+
+---
+
+---
+
+<!-- last-reviewed: 669b04f -->

--- a/src/capture/extract-frames.ts
+++ b/src/capture/extract-frames.ts
@@ -1,0 +1,79 @@
+import { spawn } from "node:child_process";
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface ExtractedFrame {
+  /** Approximate seconds-from-start, derived from output ordering × interval. */
+  t: number;
+  /** Absolute path to the extracted PNG. */
+  path: string;
+}
+
+export interface ExtractFramesOpts {
+  /** Seconds between extracted frames. */
+  intervalSeconds: number;
+  /** Hard cap on frames returned (drops trailing frames if ffmpeg produces more). */
+  maxFrames?: number;
+}
+
+/**
+ * Extract evenly-spaced frames from a webm using ffmpeg's `fps=1/N` filter.
+ *
+ * The driver always records the full session as a webm. The reasoning step
+ * uses this helper to materialize denser frames than the per-phase
+ * screenshots alone (see ADR 0005 — sparse-event aliasing). Output frames
+ * land as `frame_NNNN.png` under {@link outDir}.
+ *
+ * Requires `ffmpeg` to be on PATH. Throws if ffmpeg fails or is absent;
+ * callers should handle the failure gracefully (fall back to whatever
+ * other frames they have).
+ */
+export async function extractFrames(
+  webmPath: string,
+  outDir: string,
+  opts: ExtractFramesOpts,
+): Promise<ExtractedFrame[]> {
+  if (opts.intervalSeconds <= 0) {
+    throw new Error(`intervalSeconds must be > 0, got ${opts.intervalSeconds}`);
+  }
+  await mkdir(outDir, { recursive: true });
+  const pattern = join(outDir, "frame_%04d.png");
+
+  await runFfmpeg([
+    "-y",
+    "-loglevel",
+    "error",
+    "-i",
+    webmPath,
+    "-vf",
+    `fps=1/${opts.intervalSeconds}`,
+    "-q:v",
+    "2",
+    pattern,
+  ]);
+
+  const entries = await readdir(outDir);
+  const frames = entries
+    .filter((f) => /^frame_\d+\.png$/.test(f))
+    .sort();
+  const cap = opts.maxFrames ?? Infinity;
+  return frames.slice(0, cap).map((name, i) => ({
+    t: i * opts.intervalSeconds,
+    path: join(outDir, name),
+  }));
+}
+
+function runFfmpeg(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const ff = spawn("ffmpeg", args);
+    let stderr = "";
+    ff.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    ff.on("error", (err) => reject(new Error(`ffmpeg failed to spawn: ${err.message}`)));
+    ff.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`ffmpeg exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`));
+    });
+  });
+}

--- a/src/cli/dwell.ts
+++ b/src/cli/dwell.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { dwell } from "../drive/dwell-session";
 import { buildImpression, renderImpressionMarkdown } from "../reason/impression";
+import { validateImpression } from "../reason/validate";
 
 function parseArgs(argv: string[]): { url: string; durationMs?: number; headed: boolean } {
   const args = argv.slice(2);
@@ -69,12 +70,43 @@ async function main() {
   console.log(`  video:       ${manifest.videoPath}`);
 
   console.log(`▶ asking the model to write an impression…`);
-  const impression = await buildImpression({ manifest });
+  const initial = await buildImpression({ manifest });
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  const model = process.env.DWELL_MODEL ?? "gemini-2.5-pro";
+  let validation: Awaited<ReturnType<typeof validateImpression>> | undefined;
+  if (apiKey) {
+    const result = await validateImpression({ impression: initial, manifest, apiKey, model });
+    if (result.triggeredBy.length > 0) {
+      if (result.revised) {
+        console.log(`⚠ validation pass revised the impression (triggered by: ${result.triggeredBy.join(", ")})`);
+        if (result.revisionReason) console.log(`  reason: ${result.revisionReason}`);
+      } else {
+        console.log(`✓ validation pass confirmed (triggered by: ${result.triggeredBy.join(", ")})`);
+      }
+      validation = result;
+    }
+  }
+  const impression = validation?.impression ?? initial;
 
   const impressionsDir = join(process.cwd(), "impressions");
   await mkdir(impressionsDir, { recursive: true });
   const outPath = join(impressionsDir, `${host}-${stamp}.md`);
-  await writeFile(outPath, renderImpressionMarkdown(impression, manifest));
+  await writeFile(
+    outPath,
+    renderImpressionMarkdown(impression, manifest, {
+      ...(validation
+        ? {
+            validation: {
+              triggeredBy: validation.triggeredBy,
+              revised: validation.revised,
+              ...(validation.revisionReason !== undefined ? { reason: validation.revisionReason } : {}),
+              ...(validation.denseFramesUsed !== undefined ? { denseFramesUsed: validation.denseFramesUsed } : {}),
+            },
+          }
+        : {}),
+    }),
+  );
   console.log(`✓ impression written: ${outPath}`);
   console.log(`\n  ${impression.oneSentenceVerdict}\n`);
 }

--- a/src/reason/AGENTS.md
+++ b/src/reason/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — src/reason/
 
-The vision-model boundary. Reads a `SessionManifest` + screenshots, produces an `Impression`. This is the only file in the project that talks to an LLM.
+The vision-model boundary. Reads a `SessionManifest` + screenshots, produces an `Impression`. This is the only directory in the project that talks to an LLM.
 
 ## Index
 
@@ -8,22 +8,23 @@ The vision-model boundary. Reads a `SessionManifest` + screenshots, produces an 
 
 | File | Purpose |
 |---|---|
-| `impression.ts` | `buildImpression(opts)` calls Gemini with chronological multi-image content + structured output. `renderImpressionMarkdown(impression, manifest)` formats the result for disk. |
+| `impression.ts` | `buildImpression(opts)` — Gemini multi-image call with chronological content + structured output. Combines per-phase screenshots with dense frames extracted from the webm via `../capture/`. `renderImpressionMarkdown(...)` formats the result for disk. |
+| `validate.ts` | `validateImpression(opts)` — second pass that runs only when the impression contains stop-words (`fades`, `disappears`, `vanishes`, `stops`, `settles`, etc.). Re-samples a denser frame set via `../capture/` and asks the model to confirm or revise. See ADR 0005. |
 
 ---
 
 ## What belongs here
 
-- The system prompt for the impression task.
-- The model client (Google `@google/genai`) and the structured-output schema.
-- Frame sampling logic (we cap to 12 evenly-spaced frames to keep token cost predictable).
+- System prompts for any model task in this codebase.
+- The model client (Google `@google/genai`) and structured-output schemas.
+- Frame sampling / model-budget logic (capped at MAX_FRAMES per call to keep token cost predictable).
 - Markdown rendering of the final impression.
 
 ## What does not belong here
 
 - Driving the browser (that's `../drive/`).
 - Arg parsing (that's `../cli/`).
-- Any prompt or model call other than the impression — if a second LLM-using flow emerges, give it its own file (`impression.ts`, `summary.ts`, etc.).
+- Frame-extraction primitives — those live in `../capture/`. This module orchestrates extraction; it doesn't shell out to ffmpeg directly.
 
 ## Conventions
 

--- a/src/reason/impression.ts
+++ b/src/reason/impression.ts
@@ -1,6 +1,8 @@
 import { GoogleGenAI, Type, type Part } from "@google/genai";
 import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { z } from "zod";
+import { extractFrames, type ExtractedFrame } from "../capture/extract-frames";
 import type { SessionManifest, Impression } from "../types/session";
 
 const SYSTEM_PROMPT = `You are an experiential reviewer of websites.
@@ -29,9 +31,27 @@ export interface BuildImpressionOpts {
   manifest: SessionManifest;
   model?: string;
   apiKey?: string;
+  /**
+   * If true (default), extract additional evenly-spaced frames from the
+   * session webm via ffmpeg in addition to the per-phase screenshots.
+   * Disable for environments without ffmpeg or for debugging.
+   */
+  denseFrames?: boolean;
 }
 
 const DEFAULT_MODEL = "gemini-2.5-pro";
+/** Total frames sent to the model; covers token-cost upper bound. */
+const MAX_FRAMES = 16;
+/** Target spacing for dense frames extracted from the webm. */
+const DENSE_INTERVAL_SECONDS = 1.5;
+
+interface TimedFrame {
+  /** Seconds from session start. */
+  t: number;
+  path: string;
+  /** Short label for the chronological text annotation. */
+  label: string;
+}
 
 export async function buildImpression(opts: BuildImpressionOpts): Promise<Impression> {
   const apiKey = opts.apiKey ?? process.env.GEMINI_API_KEY;
@@ -41,13 +61,23 @@ export async function buildImpression(opts: BuildImpressionOpts): Promise<Impres
   const model = opts.model ?? process.env.DWELL_MODEL ?? DEFAULT_MODEL;
   const ai = new GoogleGenAI({ apiKey });
 
-  const screenshotEvents = opts.manifest.events.filter((e) => e.screenshotPath);
-  if (screenshotEvents.length === 0) {
-    throw new Error("No screenshots in session — nothing for the model to see.");
+  const phaseFrames: TimedFrame[] = opts.manifest.events
+    .filter((e) => e.screenshotPath)
+    .map((e) => ({
+      t: e.t / 1000,
+      path: e.screenshotPath!,
+      label: `${e.phase} · ${e.action}${e.note ? ` — ${e.note}` : ""}`,
+    }));
+
+  const denseEnabled = opts.denseFrames ?? true;
+  const denseFrames = denseEnabled ? await tryExtractDense(opts.manifest) : [];
+
+  const allFrames = [...phaseFrames, ...denseFrames].sort((a, b) => a.t - b.t);
+  if (allFrames.length === 0) {
+    throw new Error("No frames available — nothing for the model to see.");
   }
 
-  const MAX_FRAMES = 12;
-  const sampled = sampleEvenly(screenshotEvents, MAX_FRAMES);
+  const sampled = sampleEvenly(allFrames, MAX_FRAMES);
 
   const T = opts.manifest.durationMs / 1000;
   const N = sampled.length;
@@ -65,11 +95,11 @@ export async function buildImpression(opts: BuildImpressionOpts): Promise<Impres
         `The screenshots below are in chronological order. Each is preceded by a timestamp + label.`,
     },
   ];
-  for (const event of sampled) {
+  for (const frame of sampled) {
     parts.push({
-      text: `\n[t=${(event.t / 1000).toFixed(1)}s · ${event.phase} · ${event.action}${event.note ? ` — ${event.note}` : ""}]`,
+      text: `\n[t=${frame.t.toFixed(1)}s · ${frame.label}]`,
     });
-    const bytes = await readFile(event.screenshotPath!);
+    const bytes = await readFile(frame.path);
     parts.push({
       inlineData: { mimeType: "image/png", data: bytes.toString("base64") },
     });
@@ -119,14 +149,60 @@ function sampleEvenly<T>(arr: T[], max: number): T[] {
   return out;
 }
 
-export function renderImpressionMarkdown(impression: Impression, manifest: SessionManifest): string {
+async function tryExtractDense(manifest: SessionManifest): Promise<TimedFrame[]> {
+  if (!manifest.videoPath || manifest.videoPath === "(missing)") return [];
+  const T = manifest.durationMs / 1000;
+  const targetCount = Math.min(MAX_FRAMES, Math.ceil(T / DENSE_INTERVAL_SECONDS));
+  if (targetCount <= 0) return [];
+  const interval = T / targetCount;
+
+  // Frames land in a sibling of recordings/, under the same session root.
+  const sessionRoot = dirname(dirname(manifest.videoPath));
+  const denseDir = join(sessionRoot, "dense-frames");
+
+  let extracted: ExtractedFrame[];
+  try {
+    extracted = await extractFrames(manifest.videoPath, denseDir, {
+      intervalSeconds: interval,
+      maxFrames: targetCount,
+    });
+  } catch (err) {
+    // ffmpeg missing or failed — fall back to phase-aligned only. Surface the
+    // reason so users can fix it if they care, but don't crash the impression.
+    console.warn(`dwell: dense-frame extraction skipped (${err instanceof Error ? err.message : String(err)})`);
+    return [];
+  }
+
+  return extracted.map((f) => ({ t: f.t, path: f.path, label: "dense-sample" }));
+}
+
+export interface RenderImpressionOpts {
+  /** Audit metadata recorded in the markdown frontmatter. */
+  validation?: {
+    triggeredBy: string[];
+    revised: boolean;
+    reason?: string;
+    denseFramesUsed?: number;
+  };
+}
+
+export function renderImpressionMarkdown(
+  impression: Impression,
+  manifest: SessionManifest,
+  opts: RenderImpressionOpts = {},
+): string {
+  const v = opts.validation;
+  const validationFrontmatter = v
+    ? `validation_triggered_by: [${v.triggeredBy.map((s) => JSON.stringify(s)).join(", ")}]
+validation_revised: ${v.revised}${v.reason ? `\nvalidation_reason: ${JSON.stringify(v.reason)}` : ""}${v.denseFramesUsed !== undefined ? `\nvalidation_frames: ${v.denseFramesUsed}` : ""}\n`
+    : "";
   return `---
 url: ${impression.url}
 generated_at: ${impression.generatedAt}
 model: ${impression.model}
 dwell_duration_seconds: ${(manifest.durationMs / 1000).toFixed(1)}
 video: ${manifest.videoPath}
----
+${validationFrontmatter}---
 
 # ${new URL(impression.url).host}
 

--- a/src/reason/validate.ts
+++ b/src/reason/validate.ts
@@ -1,0 +1,171 @@
+import { GoogleGenAI, Type, type Part } from "@google/genai";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { z } from "zod";
+import { extractFrames } from "../capture/extract-frames";
+import type { SessionManifest, Impression } from "../types/session";
+
+/**
+ * Words/phrases that imply a permanent state change. When any of these appear
+ * in an impression that came from sparse sampling, the claim deserves a
+ * second look against denser frames — see ADR 0005.
+ */
+const STOP_WORDS_RE = /\b(fades?|fade(s|d|out)|disappears?|disappeared|vanishes?|vanished|stops?|stopped|settles?|settled|goes\s+(away|still)|fizzles?|dissipates?)\b/i;
+
+/** Returns the literal stop-word substrings found in the given text. */
+export function findStopWords(text: string): string[] {
+  const re = new RegExp(STOP_WORDS_RE, "gi");
+  const hits: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) hits.push(m[0]);
+  return hits;
+}
+
+const ValidationResponse = z.object({
+  firstFiveSeconds: z.string(),
+  afterExploration: z.string(),
+  settling: z.string(),
+  oneSentenceVerdict: z.string(),
+  revisionReason: z.string(),
+});
+
+export interface ValidateImpressionOpts {
+  impression: Impression;
+  manifest: SessionManifest;
+  apiKey: string;
+  model: string;
+}
+
+export interface ValidationResult {
+  /** The (possibly-revised) impression to ship. */
+  impression: Impression;
+  /** Stop-word hits that triggered the validation. Empty = no validation ran. */
+  triggeredBy: string[];
+  /** True if the model actually changed any of the impression fields. */
+  revised: boolean;
+  /** Model's one-line explanation of the revision (or confirmation). */
+  revisionReason?: string;
+  /** Number of denser frames used for the validation pass. */
+  denseFramesUsed?: number;
+}
+
+/**
+ * If the original impression contains stop-words, runs a second model call
+ * with a denser frame set extracted from the recording and asks the model
+ * to confirm or revise. Returns the impression to ship + an audit record.
+ *
+ * No-op when no stop-words match. ffmpeg failure or missing video falls
+ * through to a no-op as well — validation is best-effort, not load-bearing.
+ */
+export async function validateImpression(opts: ValidateImpressionOpts): Promise<ValidationResult> {
+  const { impression, manifest } = opts;
+  const corpus = `${impression.firstFiveSeconds}\n${impression.afterExploration}\n${impression.settling}\n${impression.oneSentenceVerdict}`;
+  const triggeredBy = findStopWords(corpus);
+  if (triggeredBy.length === 0) {
+    return { impression, triggeredBy: [], revised: false };
+  }
+
+  if (!manifest.videoPath || manifest.videoPath === "(missing)") {
+    return { impression, triggeredBy, revised: false };
+  }
+
+  // Denser sampling: target ~30 frames over the dwelling duration, capped.
+  const T = manifest.durationMs / 1000;
+  const targetCount = Math.min(30, Math.max(12, Math.ceil(T / 1.0)));
+  const interval = T / targetCount;
+  const sessionRoot = dirname(dirname(manifest.videoPath));
+  const validationDir = join(sessionRoot, "validation-frames");
+
+  let frames;
+  try {
+    frames = await extractFrames(manifest.videoPath, validationDir, {
+      intervalSeconds: interval,
+      maxFrames: targetCount,
+    });
+  } catch (err) {
+    console.warn(`dwell: validation-frame extraction failed (${err instanceof Error ? err.message : String(err)})`);
+    return { impression, triggeredBy, revised: false };
+  }
+
+  if (frames.length === 0) {
+    return { impression, triggeredBy, revised: false };
+  }
+
+  const ai = new GoogleGenAI({ apiKey: opts.apiKey });
+  const parts: Part[] = [
+    {
+      text:
+        `An earlier pass produced this impression of ${manifest.url} from ${manifest.events.filter((e) => e.screenshotPath).length} keyframes:\n\n` +
+        `--- ORIGINAL IMPRESSION ---\n` +
+        `First five seconds: ${impression.firstFiveSeconds}\n` +
+        `After exploration: ${impression.afterExploration}\n` +
+        `Settling: ${impression.settling}\n` +
+        `Verdict: ${impression.oneSentenceVerdict}\n` +
+        `--- END ---\n\n` +
+        `That impression contains language implying permanent state change ` +
+        `(${triggeredBy.join(", ")}). Below is a denser ${frames.length}-frame sample of the same session at ~${interval.toFixed(1)}s intervals over ${T.toFixed(1)}s.\n\n` +
+        `Confirm or revise. If a phenomenon described as fading / stopping / settling actually returns or repeats in this denser sample, fix the relevant section. If the original was correct, return the same content. Either way, fill \`revisionReason\` with a one-line explanation of what changed (or didn't, and why).`,
+    },
+  ];
+  for (const f of frames) {
+    parts.push({ text: `\n[t=${f.t.toFixed(1)}s · validation-sample]` });
+    const bytes = await readFile(f.path);
+    parts.push({
+      inlineData: { mimeType: "image/png", data: bytes.toString("base64") },
+    });
+  }
+
+  const response = await ai.models.generateContent({
+    model: opts.model,
+    contents: [{ role: "user", parts }],
+    config: {
+      systemInstruction:
+        `You are auditing an earlier impression of a website against a denser frame sample. ` +
+        `Your job is to surface periodic structure that the earlier sample missed and to correct ` +
+        `confidently-permanent claims that the denser sample shows are actually periodic. ` +
+        `Don't change content that is still supported. Don't speculate beyond the new frames. ` +
+        `Output the same Impression schema fields plus a one-line revisionReason.`,
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          firstFiveSeconds: { type: Type.STRING },
+          afterExploration: { type: Type.STRING },
+          settling: { type: Type.STRING },
+          oneSentenceVerdict: { type: Type.STRING },
+          revisionReason: { type: Type.STRING },
+        },
+        required: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict", "revisionReason"],
+        propertyOrdering: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict", "revisionReason"],
+      },
+    },
+  });
+
+  const text = response.text;
+  if (!text) {
+    return { impression, triggeredBy, revised: false, denseFramesUsed: frames.length };
+  }
+  const parsed = ValidationResponse.parse(JSON.parse(text));
+
+  const revisedImpression: Impression = {
+    ...impression,
+    firstFiveSeconds: parsed.firstFiveSeconds,
+    afterExploration: parsed.afterExploration,
+    settling: parsed.settling,
+    oneSentenceVerdict: parsed.oneSentenceVerdict,
+  };
+
+  const revised =
+    parsed.firstFiveSeconds !== impression.firstFiveSeconds ||
+    parsed.afterExploration !== impression.afterExploration ||
+    parsed.settling !== impression.settling ||
+    parsed.oneSentenceVerdict !== impression.oneSentenceVerdict;
+
+  return {
+    impression: revisedImpression,
+    triggeredBy,
+    revised,
+    revisionReason: parsed.revisionReason,
+    denseFramesUsed: frames.length,
+  };
+}


### PR DESCRIPTION
## Summary

Two of the four ADR 0005 fixes for sparse-event aliasing, bundled because they share frame-extraction infrastructure.

**#4 — decouple sampling rate from drive phase boundaries**
- New \`src/capture/extract-frames.ts\` — ffmpeg wrapper that pulls evenly-spaced PNGs from the session webm.
- \`buildImpression()\` now combines per-phase screenshots (semantic anchors: cursor was actually here) with dense frames (uniform time coverage) into one sorted pool, samples \`MAX_FRAMES\` (16) evenly. Falls back gracefully if ffmpeg fails.

**#5 — validation pass on stop-words**
- New \`src/reason/validate.ts\` — scans the impression for \`fades\`, \`disappears\`, \`vanishes\`, \`stops\`, \`settles\`, etc. When matched, extracts ~30 frames at ~1Hz and runs a second model call asking it to confirm or revise.
- Audit trail recorded in markdown frontmatter (\`validation_revised\`, \`validation_reason\`, \`validation_frames\`, \`validation_triggered_by\`).

Promotes \`src/capture/\` from Planned to a real directory; updates the src/AGENTS.md crawl map + dependency-direction diagram.

## End-to-end verification

Re-ran on \`fireside.technology\`. Original impression contained \"stops\"; validation pass with 24 dense frames revised the Settling section to correctly describe the periodic flame eruption / reformation cycle. Frontmatter records:

\`\`\`
validation_triggered_by: [\"stops\"]
validation_revised: true
validation_reason: \"The denser sample reveals that the flame's scattering and reforming is a periodic ambient animation, not a one-time settling after user interaction.\"
validation_frames: 24
\`\`\`

This is the exact failure mode the Tessera ADR was written to fix — and it self-corrected on the dogfood run.

## Test plan

- [x] \`bun run check\` + \`bun run typecheck\` pass locally
- [x] Pre-commit hook ran cleanly
- [x] End-to-end smoke run on fireside.technology revised the impression as expected
- [x] Static-site behavior unchanged (no stop-words → no second call)
- [ ] CI \`hygiene\` job passes

Closes #4. Closes #5. Part of the Tessera failure-mode fix sequence (#2 docs / #3 prompt / **#4 dense frames + #5 validation** / #6 video).