### PR TITLE
feat: --viewport flag + lazy-load deeper scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Open the produced markdown at `impressions/<host>-<timestamp>.md`.
 | Flag | Default | What it does |
 |---|---|---|
 | `--duration <seconds>` | `30` | How long to dwell. Choreography phases run inside this budget; remaining time is recorded as additional idle. |
+| `--viewport <preset\|WxH>` | `desktop` (1280×800) | Browser viewport. Presets: `desktop`, `mobile` (390×844), `tablet` (820×1180). Or pass explicit dimensions like `1920x1080`. |
 | `--headless` | off | Debug only. Real impressions require headed Chromium — see [ADR 0004](./docs/decisions/0004-headed-chromium-only.md). |
 
 ---

--- a/src/cli/dwell.ts
+++ b/src/cli/dwell.ts
@@ -5,23 +5,56 @@ import { dwell } from "../drive/dwell-session";
 import { buildImpression, renderImpressionMarkdown } from "../reason/impression";
 import { validateImpression } from "../reason/validate";
 
-function parseArgs(argv: string[]): { url: string; durationMs?: number; headed: boolean } {
+interface ParsedArgs {
+  url: string;
+  durationMs?: number;
+  headed: boolean;
+  viewport?: { width: number; height: number };
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
   const args = argv.slice(2);
   let url: string | undefined;
   let durationMs: number | undefined;
   let headed = true;
+  let viewport: { width: number; height: number } | undefined;
   for (let i = 0; i < args.length; i++) {
     const a = args[i]!;
     if (a === "--headless") headed = false;
     else if (a === "--duration") durationMs = Number(args[++i]) * 1000;
+    else if (a === "--viewport") viewport = parseViewport(args[++i]);
     else if (!url) url = a;
   }
   if (!url) {
-    console.error("usage: dwell <url> [--duration <seconds>] [--headless]");
+    console.error("usage: dwell <url> [--duration <seconds>] [--viewport <preset|WxH>] [--headless]");
+    console.error("       --viewport accepts: desktop (default), mobile, tablet, or e.g. 1920x1080");
     process.exit(2);
   }
   url = normalizeUrl(url);
-  return { url, ...(durationMs !== undefined ? { durationMs } : {}), headed };
+  return { url, ...(durationMs !== undefined ? { durationMs } : {}), headed, ...(viewport ? { viewport } : {}) };
+}
+
+const VIEWPORT_PRESETS: Record<string, { width: number; height: number }> = {
+  desktop: { width: 1280, height: 800 },
+  mobile: { width: 390, height: 844 },
+  tablet: { width: 820, height: 1180 },
+};
+
+export function parseViewport(input: string | undefined): { width: number; height: number } {
+  if (!input) {
+    console.error("error: --viewport requires a value (preset name or WxH)");
+    process.exit(2);
+  }
+  const preset = VIEWPORT_PRESETS[input.toLowerCase()];
+  if (preset) return preset;
+  const m = /^(\d+)x(\d+)$/i.exec(input);
+  if (m) {
+    const width = Number(m[1]);
+    const height = Number(m[2]);
+    if (width > 0 && height > 0) return { width, height };
+  }
+  console.error(`error: '${input}' is not a valid viewport (use 'desktop', 'mobile', 'tablet', or WxH like '1920x1080')`);
+  process.exit(2);
 }
 
 /**
@@ -50,7 +83,7 @@ function timestamp(): string {
 }
 
 async function main() {
-  const { url, durationMs, headed } = parseArgs(process.argv);
+  const { url, durationMs, headed, viewport } = parseArgs(process.argv);
   const host = slugHost(url);
   const stamp = timestamp();
   const sessionDir = join(process.cwd(), ".dwell-cache", `${host}-${stamp}`);
@@ -58,6 +91,7 @@ async function main() {
 
   console.log(`▶ dwelling on ${url}`);
   console.log(`  session dir: ${sessionDir}`);
+  if (viewport) console.log(`  viewport:    ${viewport.width}x${viewport.height}`);
   if (!headed) console.log(`  (headless mode — note that this skips visible motion)`);
 
   const manifest = await dwell({
@@ -65,6 +99,7 @@ async function main() {
     outDir: sessionDir,
     headed,
     ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(viewport ? { viewport } : {}),
   });
   console.log(`✓ recorded ${manifest.events.length} events over ${(manifest.durationMs / 1000).toFixed(1)}s`);
   console.log(`  video:       ${manifest.videoPath}`);

--- a/src/drive/dwell-session.ts
+++ b/src/drive/dwell-session.ts
@@ -8,9 +8,13 @@ export interface DwellOptions {
   outDir: string;
   durationMs?: number;
   headed?: boolean;
+  viewport?: { width: number; height: number };
 }
 
 const DEFAULT_DURATION_MS = 30_000;
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 };
+/** Cap on scroll-to-grow iterations during the scroll phase (lazy-load support). */
+const MAX_SCROLL_ITERATIONS = 5;
 
 /**
  * The dwelling strategy: open a real browser, sit with the page, and probe it
@@ -26,10 +30,11 @@ export async function dwell(opts: DwellOptions): Promise<SessionManifest> {
   await mkdir(screenshotsDir, { recursive: true });
 
   const headed = opts.headed ?? true;
+  const viewport = opts.viewport ?? DEFAULT_VIEWPORT;
   const browser: Browser = await chromium.launch({ headless: !headed });
   const context: BrowserContext = await browser.newContext({
-    viewport: { width: 1280, height: 800 },
-    recordVideo: { dir: recordingsDir, size: { width: 1280, height: 800 } },
+    viewport,
+    recordVideo: { dir: recordingsDir, size: viewport },
     deviceScaleFactor: 1,
   });
 
@@ -121,21 +126,34 @@ export async function dwell(opts: DwellOptions): Promise<SessionManifest> {
     log("hover", "affordance-probe-failed");
   }
 
-  // Phase 5: scroll the page if it's tall enough to scroll
-  const scrollHeight = await page.evaluate(() => document.documentElement.scrollHeight);
-  const viewportHeight = 800;
-  if (scrollHeight > viewportHeight + 100) {
-    await page.mouse.wheel(0, scrollHeight / 2);
+  // Phase 5: scroll the page if it's tall enough to scroll. Loops the
+  // scroll-to-bottom until either the document stops growing or the
+  // iteration cap is hit — this surfaces lazy-loaded content that's only
+  // mounted when scrolled into view.
+  const initialScrollHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+  if (initialScrollHeight > viewport.height + 100) {
+    await page.mouse.wheel(0, initialScrollHeight / 2);
     await page.waitForTimeout(800);
-    await snap("scroll", "halfway-down", `scrollHeight=${scrollHeight}`);
-    await page.mouse.wheel(0, scrollHeight);
-    await page.waitForTimeout(800);
-    await snap("scroll", "near-bottom");
-    await page.mouse.wheel(0, -scrollHeight * 2);
+    await snap("scroll", "halfway-down", `scrollHeight=${initialScrollHeight}`);
+
+    let lastHeight = initialScrollHeight;
+    let iteration = 0;
+    while (iteration < MAX_SCROLL_ITERATIONS) {
+      await page.evaluate(() => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: "instant" as ScrollBehavior }));
+      await page.waitForTimeout(900);
+      const newHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+      if (newHeight <= lastHeight + 50) break;
+      iteration += 1;
+      await snap("scroll", "lazy-grow", `iter=${iteration} height=${newHeight}`);
+      lastHeight = newHeight;
+    }
+    await snap("scroll", "near-bottom", `final-scrollHeight=${lastHeight}${iteration > 0 ? ` (${iteration} lazy-grow iters)` : ""}`);
+
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior }));
     await page.waitForTimeout(800);
     await snap("scroll", "back-to-top");
   } else {
-    log("scroll", "page-not-scrollable", `scrollHeight=${scrollHeight}`);
+    log("scroll", "page-not-scrollable", `scrollHeight=${initialScrollHeight}`);
   }
 
   // Phase 6: settle — one last frame after everything else


### PR DESCRIPTION
## Summary

Two related driver enhancements bundled because they both touch the scroll phase + CLI plumbing.

**#10 — lazy-load deeper scroll**

The scroll phase now loops scroll-to-bottom until the document stops growing or hits an iteration cap (5). Each grow iteration captures a screenshot tagged with the iter index + new height. Surfaces IntersectionObserver-triggered content; iteration cap protects against infinite-scroll feeds.

**#13 — \`--viewport\` flag**

CLI accepts \`desktop\` (default, 1280×800), \`mobile\` (390×844), \`tablet\` (820×1180), or explicit \`WxH\` like \`1920x1080\`. Plumbed through to Playwright's \`newContext\`. The previously hard-coded viewport height in the scroll phase now uses the configured value.

## Test plan

- [x] \`bun run check\` + \`bun run typecheck\` pass locally
- [x] Pre-commit hook ran cleanly
- [x] \`parseViewport\` smoke-tested on \`desktop\`, \`mobile\`, \`1920x1080\`
- [ ] CI \`hygiene\` job passes
- [ ] Spot-check (post-merge): a long lazy-loaded landing page surfaces below-the-fold content; \`--viewport mobile\` produces a mobile-layout impression

Closes #10. Closes #13.