### PR TITLE
fix(reason): bound model calls with a configurable timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ GEMINI_API_KEY=AIza...
 # Optional: override the default model used for impressions.
 # Default: gemini-2.5-pro
 # DWELL_MODEL=gemini-2.5-pro
+
+# Optional: per-call ceiling on model latency, in milliseconds.
+# Default: 120000 (120s). Bump if you regularly hit the timeout on
+# content-dense sites; drop if you'd rather fail fast on a hung API.
+# DWELL_MODEL_TIMEOUT_MS=120000

--- a/src/reason/impression.ts
+++ b/src/reason/impression.ts
@@ -44,6 +44,36 @@ const DEFAULT_MODEL = "gemini-2.5-pro";
 const MAX_FRAMES = 16;
 /** Target spacing for dense frames extracted from the webm. */
 const DENSE_INTERVAL_SECONDS = 1.5;
+/** Default ceiling on a single model call. Override with DWELL_MODEL_TIMEOUT_MS. */
+const DEFAULT_MODEL_TIMEOUT_MS = 120_000;
+
+/**
+ * Bound a promise by a timeout. Surfaces a clear error on stall instead of
+ * letting the process hang indefinitely. The underlying request may continue
+ * running in the background until the process exits — acceptable for a CLI.
+ */
+export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${(timeoutMs / 1000).toFixed(0)}s — set DWELL_MODEL_TIMEOUT_MS=<ms> to override`)),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Read the configured per-call model timeout; sane fallback if env is malformed. */
+export function modelTimeoutMs(): number {
+  const raw = process.env.DWELL_MODEL_TIMEOUT_MS;
+  if (!raw) return DEFAULT_MODEL_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MODEL_TIMEOUT_MS;
+}
 
 interface TimedFrame {
   /** Seconds from session start. */
@@ -105,7 +135,8 @@ export async function buildImpression(opts: BuildImpressionOpts): Promise<Impres
     });
   }
 
-  const response = await ai.models.generateContent({
+  const response = await withTimeout(
+    ai.models.generateContent({
     model,
     contents: [{ role: "user", parts }],
     config: {
@@ -123,7 +154,10 @@ export async function buildImpression(opts: BuildImpressionOpts): Promise<Impres
         propertyOrdering: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict"],
       },
     },
-  });
+  }),
+    modelTimeoutMs(),
+    "impression generation",
+  );
 
   const text = response.text;
   if (!text) throw new Error("Model returned no text.");

--- a/src/reason/validate.ts
+++ b/src/reason/validate.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { z } from "zod";
 import { extractFrames } from "../capture/extract-frames";
 import type { SessionManifest, Impression } from "../types/session";
+import { withTimeout, modelTimeoutMs } from "./impression";
 
 /**
  * Words/phrases that imply a permanent state change. When any of these appear
@@ -115,7 +116,8 @@ export async function validateImpression(opts: ValidateImpressionOpts): Promise<
     });
   }
 
-  const response = await ai.models.generateContent({
+  const response = await withTimeout(
+    ai.models.generateContent({
     model: opts.model,
     contents: [{ role: "user", parts }],
     config: {
@@ -139,7 +141,10 @@ export async function validateImpression(opts: ValidateImpressionOpts): Promise<
         propertyOrdering: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict", "revisionReason"],
       },
     },
-  });
+  }),
+    modelTimeoutMs(),
+    "validation pass",
+  );
 
   const text = response.text;
   if (!text) {


### PR DESCRIPTION
## Summary

Surfaced during real-world validation on \`stripe.com\` (2026-04-28): the impression call hung for 10+ minutes and had to be killed manually. \`@google/genai\` has no default client timeout and our wrappers didn't set one. A stalled request looked indistinguishable from \"still working.\"

Adds \`withTimeout()\` + \`modelTimeoutMs()\` helpers in \`src/reason/impression.ts\` and wraps both model call sites (impression generation + validation pass). Default 120s, overridable via \`DWELL_MODEL_TIMEOUT_MS\`.

On stall, the user now sees:

\`\`\`
Error: impression generation timed out after 120s — set DWELL_MODEL_TIMEOUT_MS=<ms> to override
\`\`\`

…within the budget, instead of a silent hang.

## Test plan

- [x] \`bun run check\` + \`bun run typecheck\` pass locally
- [x] Pre-commit hook ran cleanly
- [x] Smoke-tested \`withTimeout\` in isolation — 1500ms timeout fires at ~1572ms with the expected error
- [ ] CI \`hygiene\` job passes
- [ ] Spot-check post-merge: re-run \`dwell stripe.com\` and confirm it either completes or times out cleanly

Closes #23. P1 reliability bug — the kind of thing that would make a first-time OSS user abandon the project.