### PR TITLE
feat: foundation pass — timeout cancel, info-banner dismiss, ADR 0006, crawl-map fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,10 @@ GEMINI_API_KEY=AIza...
 # Default: gemini-2.5-pro
 # DWELL_MODEL=gemini-2.5-pro
 
-# Optional: per-call ceiling on model latency, in milliseconds.
+# Optional: per-stage ceiling on model latency, in milliseconds.
 # Default: 120000 (120s). Bump if you regularly hit the timeout on
 # content-dense sites; drop if you'd rather fail fast on a hung API.
+# Applies independently to the impression call and the validation pass;
+# the CLI also caps the cumulative reasoning flow at 2x this value as a
+# backstop. Both ceilings cancel the in-flight HTTP request via AbortSignal.
 # DWELL_MODEL_TIMEOUT_MS=120000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Each subdirectory has its own `AGENTS.md` with scope-specific guidance — read 
 ├── scripts/AGENTS.md               Repo-hygiene scripts (check, stamp)
 │   └── lib/AGENTS.md               Check helper modules (config, walk, git, types, individual checks)
 └── src/AGENTS.md                   Library + CLI source root
+    ├── capture/AGENTS.md           Post-recording helpers (frame extraction, log compaction); ffmpeg wrappers
     ├── cli/AGENTS.md               `dwell` CLI entry point
     ├── drive/AGENTS.md             Playwright session driver — the dwelling choreography
     ├── reason/AGENTS.md            Vision-model boundary: artifact → impression

--- a/docs/decisions/0006-experience-unit-multi-url.md
+++ b/docs/decisions/0006-experience-unit-multi-url.md
@@ -1,0 +1,67 @@
+# ADR 0006: The experience unit — scoped multi-URL dwelling
+
+## Status
+
+Proposed
+
+## Context
+
+The v0.1 scope firewall in [`AGENTS.md`](../../AGENTS.md#anti-scope-creep-firewall) lists "multi-page crawling beyond what dwelling on a single URL implies" as out of scope. That line was right for v0.1: it kept the project from sliding into being a scraper or a task agent, and it forced the dwelling choreography to focus on a single page deeply rather than many pages shallowly.
+
+A real use case has now arrived that the single-URL ceiling does not handle well. The artist-agent use case ([#27](https://github.com/LPettay/dwell/issues/27)) wants Dwell to experience a YouTube channel — `youtube.com/@CHRBRG` — the way a person does: scroll the video grid, hover thumbnails until the auto-preview triggers, click into one or two videos, watch a short segment, return. The thing being experienced is *the channel*, not any one of those URLs in isolation. A single-URL run on the `/videos` tab would miss the hover-preview behavior; a single-URL run on one video would miss the grid energy. Neither is what a human would call "dwelling on the channel."
+
+The same shape recurs elsewhere. A marketing site with `/`, `/about`, `/pricing` is one product. An artist's portfolio with `/work`, `/work/piece-a`, `/work/piece-b` is one body of work. In each case there is a *thing* with internal structure, and the unit a person would name when asked "what did you look at?" is the thing, not any single URL.
+
+The question [#30](https://github.com/LPettay/dwell/issues/30) puts on the table is whether allowing this — multiple URLs within one declared scope — violates the spirit of Dwell or extends it. This ADR resolves only that question. It does not approve any specific multi-URL driver; each one (#27, #28, #29) still has to argue its own case.
+
+## Decision
+
+Introduce the concept of an **experience unit** as the explicit scope of one dwell session.
+
+The experience unit is the upper bound of what a session is allowed to traverse. It is declared by the driver in code, not inferred at runtime and not configured by the end user. It is typed (a structured value the session driver can check), not a magic string the driver hopes to compare against.
+
+The default experience unit is **a single URL**. The current behavior. Drivers that don't opt in see no change — the v0.1 firewall continues to apply to them, because their declared unit *is* one URL.
+
+A driver may opt in to a wider unit by declaring it. The proposed YouTube channel driver (#27) declares its unit as **one channel** — concretely: the canonical channel handle, e.g. `@CHRBRG`. Within that unit the session driver may follow links from the channel grid into individual videos belonging to that channel and back to the grid. Outside that unit — a link to a sponsor's site, a suggested video from a different channel, the user's home feed, an embedded tweet — ends the session. The boundary is enforced by the session driver, not trusted to the choreography.
+
+The session manifest records the declared unit alongside the URLs visited, so a reviewer reading an impression later can see what the session was allowed to do, not just what it did.
+
+## Argument for
+
+Dwelling is about experiencing one *thing*. A YouTube channel is one thing — the same way a marketing site with multiple pages is one thing, the same way an artist's portfolio site is one thing. The unit-of-experience is what matters. The single-URL ceiling was a useful proxy for "one thing" in v0.1 because most subjects we tested against (`fireside.technology`, single landing pages) happened to fit in one URL. The proxy was never the principle.
+
+The principle is: **one session experiences one declared subject, end to end, and stops.** A session that wanders from a YouTube channel into the user's home feed has stopped experiencing the channel; the right thing for the session driver to do is end, not follow. That's the same firewall as v0.1 — it just lives at a different boundary.
+
+This also matches how the recording-then-reasoning architecture ([ADR 0003](./0003-record-then-reason.md)) already thinks about scope. The recording is a temporal artifact of one experience. If the experience is "browsing this channel for thirty seconds," the recording should cover that, not arbitrarily clip at the first navigation.
+
+## Argument against
+
+Once "experience unit" exists as a concept, its edges are fuzzy in a way the single-URL ceiling was not. "All of an artist's body of work across YouTube and Bandcamp and their personal site" is a coherent unit of experience to a human, but enforcing it as a typed boundary in a session driver is messy — it crosses platforms, crosses authentication boundaries, and at some point looks indistinguishable from a focused scrape. "Everything tagged `#design` on this site" is similarly defensible and similarly slippery.
+
+The v0.1 firewall was clear: one URL, one session. A reviewer could check it in seconds. An experience-unit firewall requires the reviewer to read the unit declaration, understand its boundary semantics, and trust that the session driver enforces the boundary correctly. That's more surface area for a contributor (or an AI agent) to argue around.
+
+The mitigation is procedural, not technical: every multi-URL driver gets its own ADR, its unit declaration is reviewed in that ADR, and a driver whose unit is "the entire web minus these excluded patterns" fails review at the ADR stage, not at the code stage.
+
+## Constraints if accepted
+
+- Each driver that opts in to a wider experience unit declares the unit in code as a typed value (e.g. a discriminated-union variant, not a free-form string). The session driver pattern-matches on the unit to decide whether a navigation is in-bounds.
+- The session driver is the enforcement point. Leaving the unit ends the session and writes out whatever was recorded up to that point. The driver does not try to "follow" or "recover" — out is out.
+- The default experience unit remains a single URL. Drivers that don't declare a wider unit get the v0.1 behavior unchanged.
+- Each new wider-unit driver requires its own ADR before implementation, the same way #27 required this one. The ADR documents the unit's boundary semantics, the rationale for that boundary, and the failure mode if the boundary is wrong.
+- The "Anti-scope-creep firewall" section in `AGENTS.md` is amended (when this ADR is accepted) to permit experience-unit-scoped multi-URL traversal *only* when an ADR-backed driver opts in. The default-out posture is preserved.
+- This ADR does not itself approve [#27](https://github.com/LPettay/dwell/issues/27), [#28](https://github.com/LPettay/dwell/issues/28), or [#29](https://github.com/LPettay/dwell/issues/29). It resolves only the meta-question of whether multi-URL sessions can ever land. Each downstream driver makes its own case.
+
+## Consequences
+
+- Unblocks the YouTube channel driver work ([#27](https://github.com/LPettay/dwell/issues/27)) to begin its own ADR and implementation, once this one is accepted.
+- Forces every future multi-URL driver through an ADR. The cost is real (one short markdown per driver) and is the point — a fuzzy boundary is acceptable only when each instance of it is reviewed deliberately.
+- The single-URL firewall is replaced by an experience-unit firewall — same spirit, different shape. A reviewer reading the repo six months from now sees that "one session, one declared subject" is the through-line, and the v0.1 single-URL rule is recognizable as a special case of it.
+- Adds one field to `SessionManifest` (the declared experience unit). This is a schema change and is small; the default value for v0.1-style runs is the single URL, so existing recordings remain readable.
+- Increases the surface area an AI agent contributing to this repo has to reason about. A future agent proposing a new driver has to declare a unit and defend it, not just write the choreography. This ADR exists in part so that defense has a vocabulary.
+
+## Alternatives considered
+
+- **Keep the single-URL firewall; reject #27 as out of scope.** Honest and easy to enforce. Rejected because it conflates the v0.1 implementation choice with a principle. The artist-agent use case is exactly the kind of "experience this thing" use case Dwell exists for; refusing it because the thing happens to span URLs would be defining the project by an arbitrary technical boundary.
+- **Allow per-driver custom navigation logic with no shared concept.** Each multi-URL driver invents its own boundary as code. Rejected — the result would be N drivers with N subtly different definitions of "in scope," no shared vocabulary in ADRs or `AGENTS.md`, and no consistent way for the session manifest to record what scope a recording was made under.
+- **Allow open-ended same-domain crawling (anything on `youtube.com`).** Simple to implement; deeply wrong. The user's YouTube home feed is on the same domain as a channel and is a different experience. A same-domain rule would let a session drift from "this channel" into "YouTube generally" without crossing any boundary the driver could detect.
+- **Defer the question; ship #27 as a one-off exception.** Rejected. The same shape will recur ([#28](https://github.com/LPettay/dwell/issues/28), [#29](https://github.com/LPettay/dwell/issues/29) and beyond). Resolving it once, with vocabulary, is cheaper than relitigating it per driver.

--- a/docs/decisions/AGENTS.md
+++ b/docs/decisions/AGENTS.md
@@ -14,6 +14,7 @@ Architecture Decision Records. One short markdown per structural choice. Numbere
 | `0003-record-then-reason.md` | Recording-then-reasoning is the architectural wedge. |
 | `0004-headed-chromium-only.md` | Headless browsing defeats the point of a dwelling tool. |
 | `0005-sparse-event-aliasing.md` | Owning the periodic-phenomena failure mode publicly in v0.1. |
+| `0006-experience-unit-multi-url.md` | (Proposed) Replace single-URL firewall with a typed experience-unit boundary. |
 
 ---
 

--- a/src/cli/dwell.ts
+++ b/src/cli/dwell.ts
@@ -2,7 +2,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { dwell } from "../drive/dwell-session";
-import { buildImpression, renderImpressionMarkdown } from "../reason/impression";
+import { buildImpression, modelTimeoutMs, renderImpressionMarkdown } from "../reason/impression";
 import { validateImpression } from "../reason/validate";
 
 interface ParsedArgs {
@@ -105,13 +105,19 @@ async function main() {
   console.log(`  video:       ${manifest.videoPath}`);
 
   console.log(`▶ asking the model to write an impression…`);
-  const initial = await buildImpression({ manifest });
+  // Cumulative backstop across the impression + validation calls. Per-stage
+  // ceilings (DWELL_MODEL_TIMEOUT_MS) still apply inside each call; this
+  // signal guarantees the whole reasoning flow can't outrun 2x the per-stage
+  // budget even if both stages stall right at their individual limits.
+  const totalBudgetMs = modelTimeoutMs() * 2;
+  const totalBudget = AbortSignal.timeout(totalBudgetMs);
+  const initial = await buildImpression({ manifest, signal: totalBudget });
 
   const apiKey = process.env.GEMINI_API_KEY;
   const model = process.env.DWELL_MODEL ?? "gemini-2.5-pro";
   let validation: Awaited<ReturnType<typeof validateImpression>> | undefined;
   if (apiKey) {
-    const result = await validateImpression({ impression: initial, manifest, apiKey, model });
+    const result = await validateImpression({ impression: initial, manifest, apiKey, model, signal: totalBudget });
     if (result.triggeredBy.length > 0) {
       if (result.revised) {
         console.log(`⚠ validation pass revised the impression (triggered by: ${result.triggeredBy.join(", ")})`);

--- a/src/drive/dwell-session.ts
+++ b/src/drive/dwell-session.ts
@@ -192,9 +192,16 @@ async function findRecording(dir: string): Promise<string | null> {
 /**
  * Best-effort dismissal of cookie / consent modals.
  *
- * Two-pass: first scans the DOM for known framework selectors (OneTrust,
- * iubenda, etc.); failing that, scans for buttons whose text content matches
- * common consent-affirmative patterns (\`Accept\`, \`Got it\`, \`I agree\`).
+ * Three-pass:
+ *   1. Known framework selectors (OneTrust, iubenda, etc.).
+ *   2. Buttons whose text matches affirmative-consent patterns (\`Accept\`,
+ *      \`Got it\`, \`I agree\`).
+ *   3. Generic info-banner dismissal — close-affordance text (\`Close\`,
+ *      \`Dismiss\`, \`No thanks\`, \`×\`) plus \`aria-label\` fallback for
+ *      icon-only X buttons. Pass 3 is geometry-guarded: it only clicks when
+ *      the candidate sits inside a fixed/sticky container that either covers
+ *      a sizeable chunk of the viewport or hugs an edge — banners do, but
+ *      tooltips, dropdowns, and inline notification badges don't.
  *
  * Heuristic by design — silent miss when no candidate is found, no false
  * positives on sign-up CTAs (we match exact text patterns, not substrings).
@@ -246,6 +253,83 @@ async function tryDismissConsent(page: Page): Promise<{ dismissed: boolean; via?
         return { selector: `[data-dwell-consent="${tag}"]`, kind: "text" };
       }
     }
+
+    // Pass 3 — info-banner dismissal affordances.
+    //
+    // Affirmative passes get first refusal so a real "Accept" wins over a
+    // nearby "X". "got it" deliberately stays in Pass 2 (affirmative) — it's
+    // closer to consent than dismissal and we don't want it duplicated.
+    const dismissPatterns = [
+      "close",
+      "dismiss",
+      "no thanks",
+      "maybe later",
+      "skip",
+      "x",
+      "×", // multiplication-sign close glyph
+    ];
+
+    // Geometry guard: a banner-like overlay either covers >20% of the
+    // viewport OR is anchored full-width / full-height to an edge. Tooltips,
+    // dropdowns, cart popovers, and inline notification badges fail both.
+    const looksLikeBanner = (el: HTMLElement): boolean => {
+      let node: HTMLElement | null = el;
+      while (node && node !== document.body) {
+        const style = getComputedStyle(node);
+        if (style.position === "fixed" || style.position === "sticky") {
+          const rect = node.getBoundingClientRect();
+          const vw = window.innerWidth;
+          const vh = window.innerHeight;
+          if (vw === 0 || vh === 0) return false;
+          const areaRatio = (rect.width * rect.height) / (vw * vh);
+          if (areaRatio > 0.2) return true;
+          // Edge anchoring: full-width band on top/bottom or full-height
+          // strip on left/right. Tolerate a few pixels of inset.
+          const fullWidth = rect.width >= vw * 0.95;
+          const fullHeight = rect.height >= vh * 0.95;
+          const hugsTop = rect.top <= 4;
+          const hugsBottom = rect.bottom >= vh - 4;
+          const hugsLeft = rect.left <= 4;
+          const hugsRight = rect.right >= vw - 4;
+          if (fullWidth && (hugsTop || hugsBottom)) return true;
+          if (fullHeight && (hugsLeft || hugsRight)) return true;
+          // A fixed/sticky ancestor that's neither big nor edge-hugging
+          // (e.g. a tooltip, popover) — bail out so we don't keep walking
+          // up into an unrelated outer fixed shell.
+          return false;
+        }
+        node = node.parentElement;
+      }
+      return false;
+    };
+
+    const tagAndReturn = (el: HTMLElement, kind: string) => {
+      const tag = `dwell-consent-${Math.random().toString(36).slice(2, 10)}`;
+      el.setAttribute("data-dwell-consent", tag);
+      return { selector: `[data-dwell-consent="${tag}"]`, kind };
+    };
+
+    // 3a: visible-text dismissal candidates.
+    for (const el of candidates) {
+      if (el.offsetParent === null) continue;
+      const text = (el.textContent ?? "").trim().toLowerCase();
+      if (!text) continue;
+      if (!dismissPatterns.includes(text)) continue;
+      if (!looksLikeBanner(el)) continue;
+      return tagAndReturn(el, "text-dismiss");
+    }
+
+    // 3b: aria-label fallback for icon-only X buttons.
+    const ariaCandidates = Array.from(document.querySelectorAll<HTMLElement>("button[aria-label], [role='button'][aria-label], a[aria-label]"));
+    for (const el of ariaCandidates) {
+      if (el.offsetParent === null) continue;
+      const label = (el.getAttribute("aria-label") ?? "").trim().toLowerCase();
+      if (!label) continue;
+      if (!dismissPatterns.includes(label)) continue;
+      if (!looksLikeBanner(el)) continue;
+      return tagAndReturn(el, "aria-dismiss");
+    }
+
     return null;
   });
 

--- a/src/reason/impression.ts
+++ b/src/reason/impression.ts
@@ -37,6 +37,13 @@ export interface BuildImpressionOpts {
    * Disable for environments without ffmpeg or for debugging.
    */
   denseFrames?: boolean;
+  /**
+   * Optional cumulative budget shared with downstream calls (e.g. the
+   * validation pass). When this signal aborts, the in-flight model request is
+   * cancelled and the call rejects. Independent from the per-stage timeout
+   * (`DWELL_MODEL_TIMEOUT_MS`) — whichever fires first wins.
+   */
+  signal?: AbortSignal;
 }
 
 const DEFAULT_MODEL = "gemini-2.5-pro";
@@ -48,22 +55,59 @@ const DENSE_INTERVAL_SECONDS = 1.5;
 const DEFAULT_MODEL_TIMEOUT_MS = 120_000;
 
 /**
- * Bound a promise by a timeout. Surfaces a clear error on stall instead of
- * letting the process hang indefinitely. The underlying request may continue
- * running in the background until the process exits — acceptable for a CLI.
+ * Run a model call under both a per-stage timeout and an optional outer
+ * AbortSignal (the caller's cumulative budget). Whichever fires first aborts
+ * the in-flight HTTP request — the @google/genai SDK honors `abortSignal`
+ * client-side, so this actually cancels the fetch instead of leaving it
+ * orphaned in the background like a `Promise.race` against a `setTimeout`.
+ *
+ * The factory is invoked synchronously with the signal so the caller can
+ * thread it into `ai.models.generateContent({ ..., config: { abortSignal } })`.
+ *
+ * On timeout the rejection message tells the user which stage tripped and
+ * which knob to turn — important now that we have both per-stage and
+ * cumulative budgets.
  */
-export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error(`${label} timed out after ${(timeoutMs / 1000).toFixed(0)}s — set DWELL_MODEL_TIMEOUT_MS=<ms> to override`)),
-      timeoutMs,
-    );
-  });
+export async function runWithTimeout<T>(
+  factory: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  label: string,
+  outerSignal?: AbortSignal,
+): Promise<T> {
+  const controller = new AbortController();
+  // Forward an already-aborted outer signal immediately so we never start the
+  // request in the first place.
+  if (outerSignal?.aborted) {
+    controller.abort(outerSignal.reason);
+  }
+  const onOuterAbort = () => controller.abort(outerSignal?.reason);
+  outerSignal?.addEventListener("abort", onOuterAbort, { once: true });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new Error(`${label} timeout`));
+  }, timeoutMs);
+
   try {
-    return await Promise.race([promise, timeoutPromise]);
+    return await factory(controller.signal);
+  } catch (err) {
+    if (timedOut) {
+      throw new Error(
+        `${label} timed out after ${(timeoutMs / 1000).toFixed(0)}s — ` +
+          `set DWELL_MODEL_TIMEOUT_MS=<ms> to raise the per-stage ceiling`,
+      );
+    }
+    if (outerSignal?.aborted) {
+      throw new Error(
+        `${label} aborted: cumulative model budget exhausted — ` +
+          `raise DWELL_MODEL_TIMEOUT_MS (per-stage) to extend the total`,
+      );
+    }
+    throw err;
   } finally {
-    if (timer) clearTimeout(timer);
+    clearTimeout(timer);
+    outerSignal?.removeEventListener("abort", onOuterAbort);
   }
 }
 
@@ -135,28 +179,31 @@ export async function buildImpression(opts: BuildImpressionOpts): Promise<Impres
     });
   }
 
-  const response = await withTimeout(
-    ai.models.generateContent({
-    model,
-    contents: [{ role: "user", parts }],
-    config: {
-      systemInstruction: SYSTEM_PROMPT,
-      responseMimeType: "application/json",
-      responseSchema: {
-        type: Type.OBJECT,
-        properties: {
-          firstFiveSeconds: { type: Type.STRING, description: "what arrival is like, 2-4 sentences" },
-          afterExploration: { type: Type.STRING, description: "what the site reveals once you poke at it, 2-4 sentences" },
-          settling: { type: Type.STRING, description: "what the site is like to sit with, 1-3 sentences" },
-          oneSentenceVerdict: { type: Type.STRING, description: "a single sentence — what is this site, in spirit?" },
+  const response = await runWithTimeout(
+    (abortSignal) =>
+      ai.models.generateContent({
+        model,
+        contents: [{ role: "user", parts }],
+        config: {
+          abortSignal,
+          systemInstruction: SYSTEM_PROMPT,
+          responseMimeType: "application/json",
+          responseSchema: {
+            type: Type.OBJECT,
+            properties: {
+              firstFiveSeconds: { type: Type.STRING, description: "what arrival is like, 2-4 sentences" },
+              afterExploration: { type: Type.STRING, description: "what the site reveals once you poke at it, 2-4 sentences" },
+              settling: { type: Type.STRING, description: "what the site is like to sit with, 1-3 sentences" },
+              oneSentenceVerdict: { type: Type.STRING, description: "a single sentence — what is this site, in spirit?" },
+            },
+            required: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict"],
+            propertyOrdering: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict"],
+          },
         },
-        required: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict"],
-        propertyOrdering: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict"],
-      },
-    },
-  }),
+      }),
     modelTimeoutMs(),
     "impression generation",
+    opts.signal,
   );
 
   const text = response.text;

--- a/src/reason/validate.ts
+++ b/src/reason/validate.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { z } from "zod";
 import { extractFrames } from "../capture/extract-frames";
 import type { SessionManifest, Impression } from "../types/session";
-import { withTimeout, modelTimeoutMs } from "./impression";
+import { runWithTimeout, modelTimeoutMs } from "./impression";
 
 /**
  * Words/phrases that imply a permanent state change. When any of these appear
@@ -35,6 +35,12 @@ export interface ValidateImpressionOpts {
   manifest: SessionManifest;
   apiKey: string;
   model: string;
+  /**
+   * Optional cumulative budget shared with the impression call. Aborting it
+   * cancels the in-flight model request and rejects the call. Independent
+   * from the per-stage timeout (`DWELL_MODEL_TIMEOUT_MS`).
+   */
+  signal?: AbortSignal;
 }
 
 export interface ValidationResult {
@@ -116,34 +122,37 @@ export async function validateImpression(opts: ValidateImpressionOpts): Promise<
     });
   }
 
-  const response = await withTimeout(
-    ai.models.generateContent({
-    model: opts.model,
-    contents: [{ role: "user", parts }],
-    config: {
-      systemInstruction:
-        `You are auditing an earlier impression of a website against a denser frame sample. ` +
-        `Your job is to surface periodic structure that the earlier sample missed and to correct ` +
-        `confidently-permanent claims that the denser sample shows are actually periodic. ` +
-        `Don't change content that is still supported. Don't speculate beyond the new frames. ` +
-        `Output the same Impression schema fields plus a one-line revisionReason.`,
-      responseMimeType: "application/json",
-      responseSchema: {
-        type: Type.OBJECT,
-        properties: {
-          firstFiveSeconds: { type: Type.STRING },
-          afterExploration: { type: Type.STRING },
-          settling: { type: Type.STRING },
-          oneSentenceVerdict: { type: Type.STRING },
-          revisionReason: { type: Type.STRING },
+  const response = await runWithTimeout(
+    (abortSignal) =>
+      ai.models.generateContent({
+        model: opts.model,
+        contents: [{ role: "user", parts }],
+        config: {
+          abortSignal,
+          systemInstruction:
+            `You are auditing an earlier impression of a website against a denser frame sample. ` +
+            `Your job is to surface periodic structure that the earlier sample missed and to correct ` +
+            `confidently-permanent claims that the denser sample shows are actually periodic. ` +
+            `Don't change content that is still supported. Don't speculate beyond the new frames. ` +
+            `Output the same Impression schema fields plus a one-line revisionReason.`,
+          responseMimeType: "application/json",
+          responseSchema: {
+            type: Type.OBJECT,
+            properties: {
+              firstFiveSeconds: { type: Type.STRING },
+              afterExploration: { type: Type.STRING },
+              settling: { type: Type.STRING },
+              oneSentenceVerdict: { type: Type.STRING },
+              revisionReason: { type: Type.STRING },
+            },
+            required: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict", "revisionReason"],
+            propertyOrdering: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict", "revisionReason"],
+          },
         },
-        required: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict", "revisionReason"],
-        propertyOrdering: ["firstFiveSeconds", "afterExploration", "settling", "oneSentenceVerdict", "revisionReason"],
-      },
-    },
-  }),
+      }),
     modelTimeoutMs(),
     "validation pass",
+    opts.signal,
   );
 
   const text = response.text;


### PR DESCRIPTION
## Summary

Bundled foundation pass — three independently-diagnosed fixes plus a proposed ADR resolving the multi-URL question raised by GeminiEditor's recent cross-repo issue filings.

- **fix(reason) #26** — Replace `Promise.race`-only timeout with AbortController-aware cancellation. The previous implementation rejected the local promise but never cancelled the underlying Gemini request, so server-side work continued past the timeout and sequential calls (impression + validation) compounded to 2× the configured budget. Now: real cancellation via `AbortSignal` threaded into `ai.models.generateContent({ config: { abortSignal } })`, plus a single shared cumulative signal at the CLI bounding the total flow at `2 * DWELL_MODEL_TIMEOUT_MS`. Error message names which stage tripped.
- **feat(drive) #24** — Extend cookie/consent dismiss heuristic with a third pass for generic info-banner X / Dismiss / Close affordances. Adds visible-text matching (`close`, `dismiss`, `no thanks`, `maybe later`, `skip`, `x`, `×`) and an `aria-label` fallback for icon-only X buttons. Guards with overlay geometry — only clicks when the candidate's nearest fixed/sticky ancestor either covers >20% of the viewport or hugs an edge full-width / full-height. Affirmative passes (1, 2) still get first refusal; banners-disguised-as-modals don't trigger this pass.
- **docs ADR 0006 (proposed)** — Resolves the multi-URL ADR question raised by issue #30. Proposes the **experience unit** concept: single URL is the default; drivers may opt into a wider unit (e.g., one YouTube channel) via per-driver ADR; the session driver enforces by ending the session if navigation strays outside the declared unit. Status `Proposed` — awaits review here. Does NOT itself accept #27, #28, or #29.
- **chore(agents)** — Fix root `AGENTS.md` crawl map (was missing `src/capture/`).

## Context

GeminiEditor's project session filed issues #27, #28, #29, #30 in this repo on 2026-05-08 — first organic cross-repo dispatch in the fleet. #30 explicitly blocked #27 on an ADR. ADR 0006 here resolves that gate.

Companion FleetManager issues filed alongside this PR (cross-repo dispatch case study, the protocol gap that surfaced, and unification of the AGENTS.md crawl infrastructure that has already begun diverging between Dwell and Tessera):

- LPettay/FleetManager#1 — extract canonical `templates/agents-crawl/`
- LPettay/FleetManager#2 — `protocol/cross-repo-dispatch.md` v1
- LPettay/FleetManager#3 — `notes/cross-repo-dispatch-genesis.md` (the GeminiEditor↔Dwell receipts)

Companion FleetManager PR opened from this same execution (proactive oversight, separate scope):

- LPettay/FleetManager#4 — `feat: proactive oversight — fleet-pulse + protocol v1`

## Closes

- closes #24
- closes #26
- partially addresses #30 (proposes ADR; gates remaining downstream issues until ADR is accepted)

## Test plan

- [x] `bun run check` — presence + forbidden + freshness all pass
- [x] `bun run typecheck` — no TS errors
- [ ] Manual: run `bun run dwell https://fireside.technology/` to confirm no regression in baseline impression flow
- [ ] Manual: run a session against a site with a known info-banner with X-close to validate the new dismiss pass
- [ ] Manual: simulate model-call hang (e.g., slow network) and confirm the timeout actually cancels the request rather than just rejecting locally

## Out of scope (deferred)

- #27 (YouTube channel driver), #28 (attention signal), #29 (creative impression mode) — all wait on ADR 0006 acceptance + per-driver follow-up ADRs.
- Cross-repo dispatch protocol (filed as FleetManager#2) — that protocol lives in FleetManager, not here.
- Adoption of `templates/agents-crawl/` in Dwell — separate PR after FleetManager#1 lands.
