### PR TITLE
docs: accept ADR 0006 + amend scope firewall (closes #30)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Out of scope:
 - **Authentication of any kind** — dwell does not log in, does not collect or store credentials, does not implement OAuth flows, does not solve CAPTCHAs. A user with their own pre-authenticated browser context is welcome to compose with dwell, but acquiring auth state is *their* problem, not dwell's.
 - **Bot-detection evasion** — no fingerprint rotation, no `playwright-stealth` integration, no residential proxies, no CAPTCHA solvers. Compose with upstream evasion tooling if needed; do not fold it in. The project's positioning is *honest observation*, not *covert observation*.
 - **Structured data scraping** — use a scraper.
-- **Multi-page crawling** beyond what dwelling on a single URL implies.
+- **Multi-page crawling** beyond what dwelling on a single declared experience unit implies. The default experience unit is one URL; a driver may declare a wider unit (e.g. one YouTube channel) only via an accepted ADR. See [ADR 0006](./docs/decisions/0006-experience-unit-multi-url.md).
 - **Running headless as the default** (defeats the point — see [ADR 0004](./docs/decisions/0004-headed-chromium-only.md)).
 - **Replacing test runners or accessibility tooling.**
 - **A web UI / dashboard for impressions.**

--- a/docs/decisions/0006-experience-unit-multi-url.md
+++ b/docs/decisions/0006-experience-unit-multi-url.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted — 2026-05-10
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Flip [ADR 0006](docs/decisions/0006-experience-unit-multi-url.md) from **Proposed** → **Accepted — 2026-05-10**.
- Amend the AGENTS.md anti-scope-creep firewall: multi-page traversal is permitted only when an ADR-backed driver opts in to a wider experience unit. Default unit remains a single URL.
- Closes #30.

## Why

ADR 0006 was drafted in #31 ("Lance accepts in PR review") but merged with status still Proposed and the firewall un-amended. This completes the acceptance the ADR's "Constraints if accepted" section calls for.

Unblocks #27 (YouTube channel driver) to begin its own ADR + implementation. #28 and #29 still argue their own cases per the ADR.

## Test plan

- [ ] `bun run check` passes (lefthook pre-commit already verified locally)
- [ ] ADR 0006 status reads `Accepted — 2026-05-10`
- [ ] AGENTS.md scope firewall references ADR 0006 and preserves default-out posture